### PR TITLE
 v 0.11

### DIFF
--- a/GameData/Nuke/KerbalChangeLog.cfg
+++ b/GameData/Nuke/KerbalChangeLog.cfg
@@ -1,0 +1,40 @@
+;KERBALCHANGELOG
+{
+	showChangelog = True
+	modName = Nuke Tiny Parts Refueled
+	VERSION
+	{
+		version = STATUS: Updating
+		change = —————————————————
+		change = [?FUTURE] Engine Pass
+		change = [?FUTURE] 
+		change = —————————————————
+		change = supports B9/NearFutureConstruction
+		change = ————————— BUG ————————
+		change = [N][BUG 0.11a] Commented out TweakScale patch for halfmeterductedfan because TweakScale was complaining
+	}
+	VERSION
+	{
+		version = 0.11
+		change = Added B9TankSwitch added with NearFutureConstruction support
+		change = Added B9TankTypes (cooperatively with NFC)
+		change = [N][BUG 0.11a] Commented out TweakScale patch for halfmeterductedfan because TweakScale was complaining
+		change = tinyGirderMediumTank: B9TankSwitch added with NearFutureConstruction support added
+		change = tinyGirderSmallTank: B9TankSwitch added with NearFutureConstruction support added
+		change = tinyGirderLargeHubTank: B9TankSwitch added with NearFutureConstruction support added
+		change = smallDeltaWing: B9TankSwitch added with NearFutureConstruction support added
+		change = halfMeterFuelTankLong: B9TankSwitch added with NearFutureConstruction support added
+		change = halfMeterFuelTankShort: B9TankSwitch added with NearFutureConstruction support added
+		change = halfMeterXenonTank: B9TankSwitch added with NearFutureConstruction support added
+		change = oneMeterXenonTank: B9TankSwitch added with NearFutureConstruction support added
+		change = halfMeterRcsTank: B9TankSwitch added with NearFutureConstruction support added with NearFutureConstruction support
+		change = updated TweakScale patches to be more specific
+	}
+	VERSION
+	{
+		version = 0.10
+		change = Converted all tga textures to dds
+		change = Uploaded to github
+		change = Added to Spacedock
+	}
+}

--- a/GameData/Nuke/Patches/B9FuelSwitch.cfg
+++ b/GameData/Nuke/Patches/B9FuelSwitch.cfg
@@ -1,0 +1,561 @@
+// Nuke Tiny Parts
+// B9PartSwitch - v 1.0
+// created: 01 Aug 19
+// updated: 02 Aug 19
+
+//size			volume		weight
+//huge			0.1269		0.0213	*
+//large			0.0648		0.0109	*
+//medium		0.0324		0.0055	*
+//small			0.0162		0.0027	*
+//tiny			0.0081		0.0014	*
+//miniscule		0.0041		0.0007	*
+//smallHub		0.01		0.0017	*
+//largeHub		0.07		0.0118	*
+//octoHub		0.04		0.0067	*
+//smallElbow	0.01		0.0017	*
+//largeElbow	0.012		0.0020	*
+//dockingPort	0.004		0.0007	*
+//hmAdapter		0.02		0.0034	*
+//tankSmall		0.01		0.0017
+//tankLarge		0.04		0.0067
+//tanked varients combine tank(s) and girder/hub volume
+//largeHubTank	0.05		0.008	*
+//mediumTank	0.0524		0.008	*
+//smallTank		0.0262		0.004	*
+
+// volume compared to NFC OctoGirder
+@PART[tinyGirderMediumTank]:NEEDS[B9PartSwitch,Nuke]:FOR[Nuke]
+{
+	MODULE
+	{
+		moduleID = fuelSwitch
+		name = ModuleB9PartSwitch
+		baseVolume = 15
+		switcherDescription = Tank Type
+		SUBTYPE
+		{
+			name = LFO
+			tankType = LFO
+			title = LFO
+		}
+		SUBTYPE
+		{
+			name = MonoPropellant
+			title = MonoPropellant
+			tankType = MonoPropellant
+		}
+		SUBTYPE
+		{
+			name = LiquidFuel
+			title = LiquidFuel
+			tankType = LiquidFuel
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Support
+			title = Station Support
+			tankType = MPEC
+		}
+		SUBTYPE:NEEDS[!NearFutureConstruction]
+		{
+			name = Support
+			title = Station Support
+			tankType = Support
+		}
+		SUBTYPE
+		{
+			name = Xenon
+			title = Xenon Gas
+			tankType = Xenon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Argon
+			title = Argon Gas
+			tankType = Argon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Lithium
+			title = Lithium
+			tankType = Lithium
+		}
+		SUBTYPE
+		{
+			name = Ore
+			title = Ore
+			tankType = Ore
+		}
+	}
+}
+
+// volume compared to NFC OctoGirder
+@PART[tinyGirderSmallTank]:NEEDS[B9PartSwitch,Nuke]:FOR[Nuke]
+{
+	MODULE
+	{
+		moduleID = fuelSwitch
+		name = ModuleB9PartSwitch
+		baseVolume = 8
+		switcherDescription = Tank Type
+		SUBTYPE
+		{
+			name = LFO
+			tankType = LFO
+			title = LFO
+		}
+		SUBTYPE
+		{
+			name = MonoPropellant
+			title = MonoPropellant
+			tankType = MonoPropellant
+		}
+		SUBTYPE
+		{
+			name = LiquidFuel
+			title = LiquidFuel
+			tankType = LiquidFuel
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Support
+			title = Support
+			tankType = MPEC
+		}
+		SUBTYPE:NEEDS[!NearFutureConstruction]
+		{
+			name = Support
+			title = Station Support
+			tankType = Support
+		}
+		SUBTYPE
+		{
+			name = Xenon
+			title = Xenon Gas
+			tankType = Xenon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Argon
+			title = Argon Gas
+			tankType = Argon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Lithium
+			title = Lithium
+			tankType = Lithium
+		}
+		SUBTYPE
+		{
+			name = Ore
+			title = Ore
+			tankType = Ore
+		}
+	}
+}
+
+@PART[tinyGirderLargeHubTank]:NEEDS[B9PartSwitch,Nuke]:FOR[Nuke]
+{
+	MODULE
+	{
+		moduleID = fuelSwitch
+		name = ModuleB9PartSwitch
+		baseVolume = 15
+		switcherDescription = Tank Type
+		SUBTYPE
+		{
+			name = LFO
+			tankType = LFO
+			title = LFO
+		}
+		SUBTYPE
+		{
+			name = MonoPropellant
+			title = MonoPropellant
+			tankType = MonoPropellant
+		}
+		SUBTYPE
+		{
+			name = LiquidFuel
+			title = LiquidFuel
+			tankType = LiquidFuel
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Support
+			title = Support
+			tankType = MPEC
+		}
+		SUBTYPE:NEEDS[!NearFutureConstruction]
+		{
+			name = Support
+			title = Station Support
+			tankType = Support
+		}
+		SUBTYPE
+		{
+			name = Xenon
+			title = Xenon Gas
+			tankType = Xenon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Argon
+			title = Argon Gas
+			tankType = Argon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Lithium
+			title = Lithium
+			tankType = Lithium
+		}
+		SUBTYPE
+		{
+			name = Ore
+			title = Ore
+			tankType = Ore
+		}
+	}
+}
+
+@PART[smallDeltaWing]:NEEDS[B9PartSwitch,Nuke]:FOR[Nuke]
+{
+	MODULE
+	{
+		moduleID = fuelSwitch
+		name = ModuleB9PartSwitch
+		baseVolume = 30
+		switcherDescription = Tank Type
+		SUBTYPE
+		{
+			name = LiquidFuel
+			title = LiquidFuel
+			tankType = LiquidFuel
+		}
+		SUBTYPE
+		{
+			name = LFO
+			tankType = LFO
+			title = LFO
+		}
+		SUBTYPE
+		{
+			name = MonoPropellant
+			title = MonoPropellant
+			tankType = MonoPropellant
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Support
+			title = Support
+			tankType = MPEC
+		}
+		SUBTYPE:NEEDS[!NearFutureConstruction]
+		{
+			name = Support
+			title = Station Support
+			tankType = Support
+		}
+		SUBTYPE
+		{
+			name = Xenon
+			title = Xenon Gas
+			tankType = Xenon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Argon
+			title = Argon Gas
+			tankType = Argon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Lithium
+			title = Lithium
+			tankType = Lithium
+		}
+		SUBTYPE
+		{
+			name = Ore
+			title = Ore
+			tankType = Ore
+		}
+	}
+}
+
+//halfMeterFuelTankLong
+@PART[halfMeterFuelTankLong]:NEEDS[B9PartSwitch,Nuke]:FOR[Nuke]
+{
+	MODULE
+	{
+		moduleID = fuelSwitch
+		name = ModuleB9PartSwitch
+		baseVolume = 500
+		switcherDescription = Tank Type
+		SUBTYPE
+		{
+			name = LFO
+			tankType = LFO
+			title = LFO
+		}
+		SUBTYPE
+		{
+			name = LiquidFuel
+			title = LiquidFuel
+			tankType = LiquidFuel
+		}
+		SUBTYPE
+		{
+			name = MonoPropellant
+			title = MonoPropellant
+			tankType = MonoPropellant
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Support
+			title = Support
+			tankType = MPEC
+		}
+		SUBTYPE:NEEDS[!NearFutureConstruction]
+		{
+			name = Support
+			title = Station Support
+			tankType = Support
+		}
+		SUBTYPE
+		{
+			name = Xenon
+			title = Xenon Gas
+			tankType = Xenon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Argon
+			title = Argon Gas
+			tankType = Argon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Lithium
+			title = Lithium
+			tankType = Lithium
+		}
+		SUBTYPE
+		{
+			name = Ore
+			title = Ore
+			tankType = Ore
+		}
+	}
+}
+
+//halfMeterFuelTankShort
+@PART[halfMeterFuelTankShort]:NEEDS[B9PartSwitch,Nuke]:FOR[Nuke]
+{
+	MODULE
+	{
+		moduleID = fuelSwitch
+		name = ModuleB9PartSwitch
+		baseVolume = 250
+		switcherDescription = Tank Type
+		SUBTYPE
+		{
+			name = LFO
+			tankType = LFO
+			title = LFO
+		}
+		SUBTYPE
+		{
+			name = LiquidFuel
+			title = LiquidFuel
+			tankType = LiquidFuel
+		}
+		SUBTYPE
+		{
+			name = MonoPropellant
+			title = MonoPropellant
+			tankType = MonoPropellant
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Support
+			title = Support
+			tankType = MPEC
+		}
+		SUBTYPE:NEEDS[!NearFutureConstruction]
+		{
+			name = Support
+			title = Station Support
+			tankType = Support
+		}
+		SUBTYPE
+		{
+			name = Xenon
+			title = Xenon Gas
+			tankType = Xenon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Argon
+			title = Argon Gas
+			tankType = Argon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Lithium
+			title = Lithium
+			tankType = Lithium
+		}
+		SUBTYPE
+		{
+			name = Ore
+			title = Ore
+			tankType = Ore
+		}
+	}
+}
+
+//halfMeterXenonTank
+@PART[halfMeterXenonTank]:NEEDS[B9PartSwitch,Nuke]:FOR[Nuke]
+{
+	MODULE
+	{
+		moduleID = fuelSwitch
+		name = ModuleB9PartSwitch
+		baseVolume = 152 // 2400
+		switcherDescription = Tank Type
+		SUBTYPE
+		{
+			name = Xenon
+			title = Xenon Gas
+			tankType = Xenon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Argon
+			title = Argon Gas
+			tankType = Argon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Lithium
+			title = Lithium
+			tankType = Lithium
+		}
+	}
+}
+
+//oneMeterXenonTank
+@PART[oneMeterXenonTank]:NEEDS[B9PartSwitch,Nuke]:FOR[Nuke]
+{
+	MODULE
+	{
+		moduleID = fuelSwitch
+		name = ModuleB9PartSwitch
+		baseVolume = 2100 // 32000
+		switcherDescription = Tank Type
+		SUBTYPE
+		{
+			name = Xenon
+			title = Xenon Gas
+			tankType = Xenon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Argon
+			title = Argon Gas
+			tankType = Argon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Lithium
+			title = Lithium
+			tankType = Lithium
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Support
+			title = Station Support
+			tankType = MPEC
+		}
+		SUBTYPE:NEEDS[!NearFutureConstruction]
+		{
+			name = Support
+			title = Station Support
+			tankType = Support
+		}
+	}
+}
+
+// halfMeterRcsTank
+@PART[halfMeterRcsTank]:NEEDS[B9PartSwitch,Nuke]:FOR[Nuke]
+{
+	MODULE
+	{
+		moduleID = fuelSwitch
+		name = ModuleB9PartSwitch
+		baseVolume = 110
+		switcherDescription = Tank Type
+		SUBTYPE
+		{
+			name = MonoPropellant
+			title = MonoPropellant
+			tankType = MonoPropellant
+		}
+		SUBTYPE
+		{
+			name = LiquidFuel
+			title = LiquidFuel
+			tankType = LiquidFuel
+		}
+		SUBTYPE
+		{
+			name = LFO
+			tankType = LFO
+			title = LFO
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Support
+			title = Support
+			tankType = MPEC
+		}
+		SUBTYPE:NEEDS[!NearFutureConstruction]
+		{
+			name = Support
+			title = Support
+			tankType = Support
+		}
+		SUBTYPE
+		{
+			name = Xenon
+			title = Xenon Gas
+			tankType = Xenon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Argon
+			title = Argon Gas
+			tankType = Argon
+		}
+		SUBTYPE:NEEDS[NearFutureConstruction]
+		{
+			name = Lithium
+			title = Lithium
+			tankType = Lithium
+		}
+	}
+}
+
+//tinyGirderSmallTank
+//tinyGirderLargeHubTank
+
+//tinyGirderLargeElbow
+//tinyGirderSmallElbow
+
+
+// zer0Kerbal
+// CC-BY-NC-SA-4.0 

--- a/GameData/Nuke/Patches/B9TankTypes.cfg
+++ b/GameData/Nuke/Patches/B9TankTypes.cfg
@@ -1,0 +1,48 @@
+// Nuke Tiny Parts
+// B9 Tank Types - v 1.0
+// created: 01 Aug 19
+// updated: 02 Aug 19
+
+B9_TANK_TYPE:NEEDS[!NearFutureConstruction]
+{
+	name = Xenon
+	tankMass = 0.00123046875
+	tankCost = 4.5
+	RESOURCE
+	{
+		name = XenonGas
+		unitsPerVolume = 15.75
+	}
+}
+
+B9_TANK_TYPE:NEEDS[!NearFutureConstruction]
+{
+	name = Support
+	tankMass = 0.000225
+	tankCost = 1.33333333333
+	RESOURCE
+	{
+		name = MonoPropellant
+		unitsPerVolume = 0.25
+	}
+	RESOURCE
+	{
+		name = ElectricCharge
+		unitsPerVolume = 1.5
+	}
+}
+
+B9_TANK_TYPE:NEEDS[!NearFutureConstruction]
+{
+	name = Ore
+	tankMass = 0.00133333333
+	tankCost = 0.83333333333
+	RESOURCE
+	{
+		name = Ore
+		unitsPerVolume = 1
+	}
+}
+
+// zer0Kerbal
+// CC-BY-NC-SA-4.0 

--- a/GameData/Nuke/Patches/tweakscale.cfg
+++ b/GameData/Nuke/Patches/tweakscale.cfg
@@ -1,727 +1,728 @@
 //aero
-@PART[halfMeterShockInlet]:NEEDS[TweakScale]
+@PART[halfMeterShockInlet]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterTailBoom]:NEEDS[TweakScale]
+@PART[halfMeterTailBoom]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[smallGliderWing]:NEEDS[TweakScale]
+@PART[smallGliderWing]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
-@PART[smallDeltaWing]:NEEDS[TweakScale]
+@PART[smallDeltaWing]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
-@PART[smallCanard]:NEEDS[TweakScale]
+@PART[smallCanard]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
-@PART[smallAeroPylon]:NEEDS[TweakScale]
+@PART[smallAeroPylon]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
-@PART[smallTailFin]:NEEDS[TweakScale]
+@PART[smallTailFin]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
-@PART[smallSolarWing]:NEEDS[TweakScale]
+@PART[smallSolarWing]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
 
 //electrical
-@PART[halfMeterBattery]:NEEDS[TweakScale]
+@PART[halfMeterBattery]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
 
 //engine
-@PART[halfMeterArcjet]:NEEDS[TweakScale]
+@PART[halfMeterArcjet]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterDuctedFan]:NEEDS[TweakScale]
+// @PART[halfMeterDuctedFan]:NEEDS[TweakScale]:FOR[Nuke]
+// {
+	// !MODULE[TweakScale] {}
+	// MODULE
+	// {
+		// &name = TweakScale
+		// &type = stack
+		// &defaultScale = 0.625
+		// //&freeScale = True
+	// }
+// }
+
+@PART[halfMeterFixedEngine]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterFixedEngine]:NEEDS[TweakScale]
+@PART[halfMeterGimballedEngine]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterGimballedEngine]:NEEDS[TweakScale]
+@PART[halfMeterJetEngine]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterJetEngine]:NEEDS[TweakScale]
+@PART[halfMeterMpdThruster]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterMpdThruster]:NEEDS[TweakScale]
+@PART[halfMeterVtolEngine]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterVtolEngine]:NEEDS[TweakScale]
+@PART[halfMeterVtolRocket]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterVtolRocket]:NEEDS[TweakScale]
+@PART[oneMeterDualMpdThruster]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
-}
-
-@PART[oneMeterDualMpdThruster]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 1.25
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 1.25
+		&freeScale = True
+	}
 }
 
 
 //fuel tank
-@PART[halfMeterJetFuelTank]:NEEDS[TweakScale]
+@PART[halfMeterJetFuelTank]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterOxyTank]:NEEDS[TweakScale]
+@PART[halfMeterOxyTank]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterRcsTank]:NEEDS[TweakScale]
+@PART[halfMeterRcsTank]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterFuelTankLong]:NEEDS[TweakScale]
+@PART[halfMeterFuelTankLong]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterFuelTankShort]:NEEDS[TweakScale]
+@PART[halfMeterFuelTankShort]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterXenonTank]:NEEDS[TweakScale]
+@PART[halfMeterXenonTank]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[oneMeterXenonTank]:NEEDS[TweakScale]
+@PART[oneMeterXenonTank]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 1.25
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 1.25
+		&freeScale = True
+	}
 }
 
 
 //structural
-@PART[halfToOneMeterAdapter]:NEEDS[TweakScale]
+@PART[halfToOneMeterAdapter]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterBicoupler]:NEEDS[TweakScale]
+@PART[halfMeterBicoupler]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterEnginePylon]:NEEDS[TweakScale]
+@PART[halfMeterEnginePylon]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterInlineTricoupler]:NEEDS[TweakScale]
+@PART[halfMeterInlineTricoupler]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterRadialAdapter]:NEEDS[TweakScale]
+@PART[halfMeterRadialAdapter]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterRadialTricoupler]:NEEDS[TweakScale]
+@PART[halfMeterRadialTricoupler]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[HalfMeterStationHub]:NEEDS[TweakScale]
+@PART[HalfMeterStationHub]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterStructuralLatticeBent]:NEEDS[TweakScale]
+@PART[halfMeterStructuralLatticeBent]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
-@PART[halfMeterStructuralLatticeDock]:NEEDS[TweakScale]
+@PART[halfMeterStructuralLatticeDock]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
-@PART[halfMeterStructuralLatticeHuge]:NEEDS[TweakScale]
+@PART[halfMeterStructuralLatticeHuge]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
-@PART[halfMeterStructuralLatticeLarge]:NEEDS[TweakScale]
+@PART[halfMeterStructuralLatticeLarge]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
-@PART[halfMeterStructuralLatticeMedium]:NEEDS[TweakScale]
+@PART[halfMeterStructuralLatticeMedium]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
-@PART[halfMeterStructuralLatticeSmall]:NEEDS[TweakScale]
+@PART[halfMeterStructuralLatticeSmall]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
-@PART[halfMeterStructuralLatticeTiny]:NEEDS[TweakScale]
+@PART[halfMeterStructuralLatticeTiny]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
-@PART[halfMeterStructuralLatticeSpacer]:NEEDS[TweakScale]
+@PART[halfMeterStructuralLatticeSpacer]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
-}
-
-@PART[quadHalfMeterToMeterAdapter]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 1.25
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[tinyGirderSmallElbow]:NEEDS[TweakScale]
+@PART[quadHalfMeterToMeterAdapter]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderLargeElbow]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderHuge]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderLarge]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderMedium]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderSmall]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderTiny]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderMiniscule]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderSmallHub]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderLargeHub]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderOctoHub]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
-}
-@PART[tinyGirderHalfMeterAdapter]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
-}
-@PART[tinyGirderDock]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderMediumTank]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderSmallTank]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderLargeHubTank]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderExplodie]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderLfArcjetThruster]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderIonThruster]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
-}
-@PART[tinyGirderGimballedMonoThruster]:NEEDS[TweakScale]
-{
-	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.3125
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 1.25
+		&freeScale = True
+	}
 }
 
-@PART[nineteenEngineCoupler]:NEEDS[TweakScale]
+@PART[tinyGirderSmallElbow]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 3.75
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderLargeElbow]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderHuge]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderLarge]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderMedium]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderSmall]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderTiny]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderMiniscule]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderSmallHub]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderLargeHub]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderOctoHub]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
+}
+@PART[tinyGirderHalfMeterAdapter]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
+}
+@PART[tinyGirderDock]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderMediumTank]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderSmallTank]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderLargeHubTank]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderExplodie]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderLfArcjetThruster]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderIonThruster]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+@PART[tinyGirderGimballedMonoThruster]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 0.3125
+		&freeScale = True
+	}
+}
+
+@PART[nineteenEngineCoupler]:NEEDS[TweakScale]:FOR[Nuke]
+{
+	MODULE
+	{
+		&name = TweakScale
+		&type = stack
+		defaultScale = 3.75
+		&freeScale = True
+	}
 }
 
 
 //utility
-@PART[BleedThruster]:NEEDS[TweakScale]
+@PART[BleedThruster]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[BleedThrusterQuad]:NEEDS[TweakScale]
+@PART[BleedThrusterQuad]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[halfMeterRcsNosecone]:NEEDS[TweakScale]
+@PART[halfMeterRcsNosecone]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[HallThruster]:NEEDS[TweakScale]
+@PART[HallThruster]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[HallThrusterQuad]:NEEDS[TweakScale]
+@PART[HallThrusterQuad]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }
 
-@PART[lightRadialDecoupler]:NEEDS[TweakScale]
+@PART[lightRadialDecoupler]:NEEDS[TweakScale]:FOR[Nuke]
 {
 	MODULE
-    {
-        name = TweakScale
-        type = stack
-        defaultScale = 0.625
-		freeScale = True
-    }
+	{
+		&name = TweakScale
+		&type = stack
+		&defaultScale = 0.625
+		&freeScale = True
+	}
 }

--- a/GameData/Nuke/changelog.md
+++ b/GameData/Nuke/changelog.md
@@ -1,0 +1,17 @@
++ v 0.11 
+	+ Add B9 tank switch (with NearFutureConstruction Support) to :
+		+ tinyGirderMediumTank
+		+ tinyGirderSmallTank
+		+ tinyGirderLargeHubTank
+		+ smallDeltaWing
+		+ halfMeterFuelTankLong
+		+ halfMeterFuelTankShort
+		+ halfMeterXenonTank
+		+ oneMeterXenonTank
+		+ halfMeterRcsTank
+	+ BUG: TweakScale doesn't like halfmeterductedfan
+	+ Updated TweakScale patch to be more specific
++ v 0.10
+	+ Converted all tga textures to dds
+	+ Uploaded to github
+	+ Added to Spacedock


### PR DESCRIPTION
# v 0.11
	+ Add B9 tank switch (with NearFutureConstruction Support) to :
		+ tinyGirderMediumTank
		+ tinyGirderSmallTank
		+ tinyGirderLargeHubTank
		+ smallDeltaWing
		+ halfMeterFuelTankLong
		+ halfMeterFuelTankShort
		+ halfMeterXenonTank
		+ oneMeterXenonTank
		+ halfMeterRcsTank
	+ BUG: TweakScale doesn't like halfmeterductedfan
	+ Updated TweakScale patch to be more specific